### PR TITLE
Fix crackling noise

### DIFF
--- a/src/main/java/vavi/sound/pcm/resampling/ssrc/SSRC.java
+++ b/src/main/java/vavi/sound/pcm/resampling/ssrc/SSRC.java
@@ -618,10 +618,10 @@ public class SSRC {
 
             buf2 = new double[nch][n2b];
 
-            rawinbuf = ByteBuffer.allocate(nch * (n2b2 + n1x) * bps); // ,bps
+            rawinbuf = ByteBuffer.allocate(nch * (n2b2 + n1x + 2) * bps); // ,bps
             rawoutbuf = ByteBuffer.allocate(nch * (n2b2 / osf + 1) * dbps); // ,dbps
 
-            inbuf = new double[nch * (n2b2 + n1x)];
+            inbuf = new double[nch * (n2b2 + n1x + 2)];
             outbuf = new double[nch * (n2b2 / osf + 1)];
 
             s1p = 0;
@@ -639,13 +639,13 @@ public class SSRC {
             while (true) {
                 int nsmplread, toberead, toberead2;
 
-                toberead2 = toberead = (int) (Math.floor((double) n2b2 * sfrq / (dfrq * osf)) + 1 + n1x - inbuflen);
+                toberead2 = toberead = (int) (Math.ceil((double) n2b2 * sfrq / (dfrq * osf)) + 1 + n1x - inbuflen);
                 if (toberead + sumread > chanklen) {
                     toberead = chanklen - sumread;
                 }
 
                 rawinbuf.position(0);
-                rawinbuf.limit(Math.min(rawinbuf.limit(), bps * nch * toberead));
+                rawinbuf.limit(bps * nch * toberead);
 //                rawinbuf.limit(bps * nch * toberead);
 
                 byte[] tempData = new byte[rawinbuf.limit()];
@@ -989,12 +989,12 @@ public class SSRC {
                         if (ending) {
                             if ((double) sumread * dfrq / sfrq + 2 > sumwrite + nsmplwrt2 - delay) {
                                 rawoutbuf.position(dbps * nch * delay);
-                                rawoutbuf.limit(dbps * nch * (nsmplwrt2 - delay));
+                                rawoutbuf.limit(dbps * nch * nsmplwrt2);
                                 writeBuffers(fpo, rawoutbuf);
                                 sumwrite += nsmplwrt2 - delay;
                             } else {
                                 rawoutbuf.position(dbps * nch * delay);
-                                rawoutbuf.limit((int) (dbps * nch * (Math.floor((double) sumread * dfrq / sfrq) + 2 + sumwrite + nsmplwrt2 - delay)));
+                                rawoutbuf.limit((int) (dbps * nch * (Math.floor((double) sumread * dfrq / sfrq) + 2 - sumwrite)));
                                 writeBuffers(fpo, rawoutbuf);
                                 break;
                             }

--- a/src/main/java/vavi/sound/pcm/resampling/ssrc/SSRC.java
+++ b/src/main/java/vavi/sound/pcm/resampling/ssrc/SSRC.java
@@ -37,13 +37,13 @@ public class SSRC {
     private static final String VERSION = "1.30";
 
     /** */
-    private double AA = 170;
+    private double AA = 150;
 
     /** */
-    private double DF = 100;
+    private double DF = 200;
 
     /** */
-    private int FFTFIRLEN = 65536;
+    private int FFTFIRLEN = 1;
 
     /** */
 //  private static final int M = 15;


### PR DESCRIPTION
I found that the line responsible for the crackling noise is:
`rawinbuf.limit(Math.min(rawinbuf.limit(), bps * nch * toberead));`
from line 648. Details about what happens can be found in issue #2.

In the process I did a full compare with the original  C version by Shibatch, and corrected the differences. I found that the result works fine for various sample rates, and also has improved speed after modifying the hardcoded settings (AA, DF and FFTFIRLEN)
